### PR TITLE
Add trivial dead code elimination

### DIFF
--- a/brench/cs6120.toml
+++ b/brench/cs6120.toml
@@ -1,0 +1,22 @@
+extract = 'total_dyn_inst: (\d+)'
+benchmarks = '../benchmarks/core/*.bril'
+
+[runs.baseline]
+pipeline = [
+    "bril2json",
+    "brili -p {args}",
+]
+
+[runs.tdce]
+pipeline = [
+    "bril2json",
+    "tdce",
+    "brili -p {args}",
+]
+
+[runs.tdce_plus]
+pipeline = [
+    "bril2json",
+    "tdce+",
+    "brili -p {args}",
+]

--- a/tdce/LICENSE
+++ b/tdce/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2024 Lai-YT
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/tdce/pyproject.toml
+++ b/tdce/pyproject.toml
@@ -1,0 +1,14 @@
+[build-system]
+requires = ["flit_core >=3.2,<4"]
+build-backend = "flit_core.buildapi"
+
+[project]
+name = "tdce"
+authors = [{name = "Lai-YT", email = "381xvmvbib@gmail.com"}]
+license = {file = "LICENSE"}
+classifiers = ["License :: OSI Approved :: MIT License"]
+dynamic = ["version", "description"]
+
+[project.scripts]
+tdce = "tdce:tdce"
+"tdce+" = "tdce:tdce_plus"

--- a/tdce/tdce.py
+++ b/tdce/tdce.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+
+"""Trivial Dead Code Elimination.
+
+This module defines two kinds of tdce optimization:
+(1) `tdce`: Removes defs with no use. This is a global optimization.
+(2) `tdce+`: Augments `tdce` by removing defs that have been re-defined later without a use in between. This has no effect if the program is already in SSA-form.
+"""
+
+__version__ = "0.1.0"
+
+import json
+import sys
+from typing import Any, Callable, Dict, List, MutableMapping, Set, TypeAlias
+
+import cfg  # type: ignore
+
+Instr: TypeAlias = MutableMapping[str, Any]
+
+
+def remove_def_with_no_use(instrs: List[Instr]) -> List[Instr]:
+    """Remove definitions with no uses.
+
+    Args:
+        instrs: A list of instructions.
+
+    Returns:
+        A list of instructions with definitions that have no uses removed.
+    """
+    used: Set[str] = set()
+    for instr in instrs:
+        if "args" in instr:  # is a use
+            used = used.union(instr["args"])
+    if not used:
+        return instrs
+    # Now, all variables that have uses are collected.
+    # We walk through the instructions again and remove defs without a use.
+    return [instr for instr in instrs if "dest" not in instr or instr["dest"] in used]
+
+
+def remove_re_def_with_no_use_between(instrs: List[Instr]) -> List[Instr]:
+    """Remove re-definitions with no uses between them.
+
+    Args:
+        instrs: A list of instructions.
+
+    Returns:
+        A list of instructions with re-definitions that have no uses between them removed.
+    """
+    for block in cfg.form_blocks(instrs):
+        unused: Dict[str, Instr] = {}
+        for instr in block:
+            # An instruction may use and define a variable at the same time;
+            # such a variable is considered used, followed by a new def that is unused.
+            if "args" in instr:  # is a use
+                for arg in instr["args"]:
+                    unused.pop(arg, None)
+            if "dest" in instr:  # is a def
+                if instr["dest"] in unused:
+                    # Mark the instruction as dead, so we know it should be removed from the program.
+                    unused[instr["dest"]]["is_dead"] = True
+                unused[instr["dest"]] = instr
+    # Now, the dead defs are collected; remove them from the program.
+    return [instr for instr in instrs if "is_dead" not in instr]
+
+
+def main(passes: List[Callable[[List[Instr]], List[Instr]]]) -> None:
+    prog: Dict[str, List[Dict[str, Any]]] = json.load(sys.stdin)
+
+    for func in prog["functions"]:
+        for pass_ in passes:
+            while True:
+                instrs: List[Instr] = func["instrs"]
+                res = pass_(instrs)
+                if len(res) == len(instrs):
+                    # converges
+                    break
+                func["instrs"] = res
+
+    json.dump(prog, indent=2, fp=sys.stdout)
+
+
+# Command-line entry points.
+
+
+def tdce() -> None:
+    main([remove_def_with_no_use])
+
+
+def tdce_plus() -> None:
+    main([remove_def_with_no_use, remove_re_def_with_no_use_between])


### PR DESCRIPTION
This pull request introduces the implementation of the Trivial Dead Code Elimination (TDCE) optimization as part of lesson 3. The optimization can be installed using `flit`.

Two commands are provided:

- `tdce`: Performs a global optimization by removing definitions that are not used.
- `tdce+`: Enhances `tdce` by additionally removing definitions that are redefined later without any use in between. This command has the same effect as `tdce` if the program is already in SSA-form.

Additionally, a `brench` configuration is added to run the trivial dead code elimination on the core benchmarks with the following command:

```console
brench brench/cs6120.toml
```