### PR TITLE
Add basic local value numbering

### DIFF
--- a/brench/cs6120.toml
+++ b/brench/cs6120.toml
@@ -20,3 +20,11 @@ pipeline = [
     "tdce+",
     "brili -p {args}",
 ]
+
+[runs.lvn]
+pipeline = [
+    "bril2json",
+    "lvn",
+    "tdce+",
+    "brili -p {args}",
+]

--- a/lvn/LICENSE
+++ b/lvn/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2024 Lai-YT
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/lvn/lvn.py
+++ b/lvn/lvn.py
@@ -1,5 +1,6 @@
-"""
-This module defines the local value numbering.
+"""This module defines the basic local value numbering.
+
+Constant propagation and folding are not supported.
 """
 
 __version__ = "0.1.0"

--- a/lvn/lvn.py
+++ b/lvn/lvn.py
@@ -22,6 +22,11 @@ def rename_args_between(instrs: List[cfg.Instr], old_name: str, new_name: str) -
                 args[i] = new_name
 
 
+def has_side_effect(op: str) -> bool:
+    """Returns whether the `op` may have side effect."""
+    return op == "call"
+
+
 def lvn() -> None:
     prog: Dict[str, List[Dict[str, Any]]] = json.load(sys.stdin)
 
@@ -78,7 +83,7 @@ def lvn() -> None:
                         val = Value(*sorted(row_nums, key=lambda x: str(x)))
                     val = Value(op, row_nums)
 
-                if val in val2var:
+                if val in val2var and not has_side_effect(val.op):
                     # The value has been computed before;
                     # map it to the canonical variable without adding a new row.
                     var, the_row_num = val2var[val]

--- a/lvn/lvn.py
+++ b/lvn/lvn.py
@@ -28,6 +28,11 @@ def has_side_effect(op: str) -> bool:
     return op == "call"
 
 
+def is_commutative(op: str) -> bool:
+    # No short circuit for "add" and "or" at this level.
+    return op in ("add", "mul", "eq", "add", "or")
+
+
 def lvn() -> None:
     prog: Dict[str, List[Dict[str, Any]]] = json.load(sys.stdin)
 
@@ -79,7 +84,7 @@ def lvn() -> None:
                     row_nums: Tuple[Union[str, int], ...] = tuple(
                         var2num.get(arg, arg) for arg in instr["args"]
                     )
-                    if op == "add":
+                    if is_commutative(op):
                         # Commutativity; sort the args to canonicalize.
                         # NOTE: Row numbers can be str if is defined in other basic block.
                         val = Value(*sorted(row_nums, key=lambda x: str(x)))

--- a/lvn/lvn.py
+++ b/lvn/lvn.py
@@ -1,0 +1,113 @@
+"""
+This module defines the local value numbering.
+"""
+
+__version__ = "0.1.0"
+
+import json
+import sys
+from typing import Any, Dict, List, Tuple, Union
+
+import cfg
+
+
+def rename_args_between(instrs: List[cfg.Instr], old_name: str, new_name: str) -> None:
+    for instr in instrs:
+        args = instr.get("args", [])
+        for i, arg in enumerate(args):
+            if arg == old_name:
+                args[i] = new_name
+
+
+def lvn() -> None:
+    prog: Dict[str, List[Dict[str, Any]]] = json.load(sys.stdin)
+
+    for func in prog["functions"]:
+        # The l of lvn is for local.
+        for block in cfg.form_blocks(func["instrs"]):
+            row_num = 0
+            # Map the tuple value to its canonical variable with the row number wrapped together.
+            # A value consists of an operator, along with its row number (or constant value).
+            val2var: Dict[Tuple, Tuple[str, int]] = {}
+            # Map the variable to the row number of its value.
+            var2num: Dict[str, int] = {}
+
+            def replace_args_with_canonical(instr: cfg.Instr) -> None:
+                for i, arg in enumerate(instr.get("args", [])):
+                    # Def of arg is in other basic block; not to touch it.
+                    if arg not in var2num:
+                        continue
+                    the_row_num = var2num[arg]
+                    # NOTE: This requires the dict to be ordered, and the row number must exactly match the ordered we added.
+                    instr["args"][i] = list(val2var.values())[the_row_num][0]
+
+            # Used to rename variables that are reassigned.
+            lvn_number = 0
+
+            for i, instr in enumerate(block):
+                if "label" in instr or ("dest" not in instr and "args" not in instr):
+                    continue
+
+                if "dest" not in instr:
+                    # Not an assignment; only perform replacement.
+                    # NOTE: Always replace; may be the same.
+                    replace_args_with_canonical(instr)
+                    continue
+
+                if instr["op"] == "const":
+                    # NOTE: Since False is equal to 0 in Python, we have to include the type.
+                    val = "const", instr["value"], instr["type"]
+                else:
+                    # NOTE: If the variable isn't record, it's because such variable is defined in another basic block.
+                    # In such case, there's no column number, we use the variable name directly in the tuple value.
+
+                    # For function calls, we postfix the function name to the op to differentiate.
+                    op = instr["op"]
+                    if "funcs" in instr:
+                        op += instr["funcs"][0]
+
+                    # Lookup the row numbers of the operands.
+                    row_nums: List[Union[str, int]] = []
+                    for arg in instr["args"]:
+                        row_nums.append(var2num.get(arg, arg))
+                    if op == "add":
+                        # Commutativity; sort the args to canonicalize.
+                        # NOTE: Row numbers can be str if is defined in other basic block.
+                        row_nums.sort(key=lambda x: str(x))
+                    val = op, *row_nums
+
+                if val in val2var:
+                    # The value has been computed before;
+                    # map it to the canonical variable without adding a new row.
+                    var, the_row_num = val2var[val]
+                    # Replace the instruction as directly using the canonical variable to eliminate the computation.
+                    # TODO: constant propagation
+                    instr["op"] = "id"
+                    instr["args"] = [var]
+                else:
+                    # If the variable is going to be reassigned, we give it an unique name so that the value is correct when later instructions use it as the canonical variable.
+                    dest = instr["dest"]
+                    for j in range(i + 1, len(block)):  # peek the later instructions
+                        later_instr = block[j]
+                        if dest == later_instr.get("dest", None):
+                            new_name = f"{dest}.{lvn_number}"
+                            lvn_number += 1
+                            # all args between should be updated to use the new name.
+                            # j + 1 because may be used in the reassignment.
+                            rename_args_between(block[i + 1 : j + 1], dest, new_name)
+                            dest = new_name
+                            instr["dest"] = dest
+                            break
+
+                    # A new value.
+                    the_row_num = row_num
+                    row_num += 1
+                    val2var[val] = dest, the_row_num
+
+                    # As long as all previous instructions are canonicalize,
+                    # there's no difference between replacing here or earlier.
+                    replace_args_with_canonical(instr)
+
+                var2num[instr["dest"]] = the_row_num
+
+    json.dump(prog, indent=2, fp=sys.stdout)

--- a/lvn/lvn.py
+++ b/lvn/lvn.py
@@ -6,9 +6,12 @@ __version__ = "0.1.0"
 
 import json
 import sys
+from collections import namedtuple
 from typing import Any, Dict, List, Tuple, Union
 
 import cfg
+
+Value = namedtuple("Value", ["op", "args"])
 
 
 def rename_args_between(instrs: List[cfg.Instr], old_name: str, new_name: str) -> None:
@@ -28,7 +31,7 @@ def lvn() -> None:
             row_num = 0
             # Map the tuple value to its canonical variable with the row number wrapped together.
             # A value consists of an operator, along with its row number (or constant value).
-            val2var: Dict[Tuple, Tuple[str, int]] = {}
+            val2var: Dict[Value, Tuple[str, int]] = {}
             # Map the variable to the row number of its value.
             var2num: Dict[str, int] = {}
 
@@ -39,7 +42,8 @@ def lvn() -> None:
                         continue
                     the_row_num = var2num[arg]
                     # NOTE: This requires the dict to be ordered, and the row number must exactly match the ordered we added.
-                    instr["args"][i] = list(val2var.values())[the_row_num][0]
+                    var, _ = list(val2var.values())[the_row_num]
+                    instr["args"][i] = var
 
             # Used to rename variables that are reassigned.
             lvn_number = 0
@@ -49,14 +53,12 @@ def lvn() -> None:
                     continue
 
                 if "dest" not in instr:
-                    # Not an assignment; only perform replacement.
-                    # NOTE: Always replace; may be the same.
-                    replace_args_with_canonical(instr)
+                    # Not an assignment.
                     continue
 
                 if instr["op"] == "const":
                     # NOTE: Since False is equal to 0 in Python, we have to include the type.
-                    val = "const", instr["value"], instr["type"]
+                    val = Value("const", (instr["value"], instr["type"]))
                 else:
                     # NOTE: If the variable isn't record, it's because such variable is defined in another basic block.
                     # In such case, there's no column number, we use the variable name directly in the tuple value.
@@ -67,23 +69,23 @@ def lvn() -> None:
                         op += instr["funcs"][0]
 
                     # Lookup the row numbers of the operands.
-                    row_nums: List[Union[str, int]] = []
-                    for arg in instr["args"]:
-                        row_nums.append(var2num.get(arg, arg))
+                    row_nums: Tuple[Union[str, int], ...] = tuple(
+                        var2num.get(arg, arg) for arg in instr["args"]
+                    )
                     if op == "add":
                         # Commutativity; sort the args to canonicalize.
                         # NOTE: Row numbers can be str if is defined in other basic block.
-                        row_nums.sort(key=lambda x: str(x))
-                    val = op, *row_nums
+                        val = Value(*sorted(row_nums, key=lambda x: str(x)))
+                    val = Value(op, row_nums)
 
                 if val in val2var:
                     # The value has been computed before;
                     # map it to the canonical variable without adding a new row.
                     var, the_row_num = val2var[val]
-                    # Replace the instruction as directly using the canonical variable to eliminate the computation.
-                    # TODO: constant propagation
-                    instr["op"] = "id"
-                    instr["args"] = [var]
+                    if val.op != "const":
+                        # Replace the instruction as directly using the canonical variable to eliminate the computation.
+                        instr["op"] = "id"
+                        instr["args"] = [var]
                 else:
                     # If the variable is going to be reassigned, we give it an unique name so that the value is correct when later instructions use it as the canonical variable.
                     dest = instr["dest"]
@@ -104,8 +106,6 @@ def lvn() -> None:
                     row_num += 1
                     val2var[val] = dest, the_row_num
 
-                    # As long as all previous instructions are canonicalize,
-                    # there's no difference between replacing here or earlier.
                     replace_args_with_canonical(instr)
 
                 var2num[instr["dest"]] = the_row_num

--- a/lvn/lvn.py
+++ b/lvn/lvn.py
@@ -55,11 +55,12 @@ def lvn() -> None:
             lvn_number = 0
 
             for i, instr in enumerate(block):
-                if "label" in instr or ("dest" not in instr and "args" not in instr):
+                if "label" in instr:
                     continue
 
                 if "dest" not in instr:
                     # Not an assignment.
+                    replace_args_with_canonical(instr)
                     continue
 
                 if instr["op"] == "const":

--- a/lvn/pyproject.toml
+++ b/lvn/pyproject.toml
@@ -1,0 +1,13 @@
+[build-system]
+requires = ["flit_core >=3.2,<4"]
+build-backend = "flit_core.buildapi"
+
+[project]
+name = "lvn"
+authors = [{name = "Lai-YT", email = "381xvmvbib@gmail.com"}]
+license = {file = "LICENSE"}
+classifiers = ["License :: OSI Approved :: MIT License"]
+dynamic = ["version", "description"]
+
+[project.scripts]
+lvn = "lvn:lvn"


### PR DESCRIPTION
This pull request introduces the implementation of Local Value Numbering (LVN) as the second part of lesson 3. This opens up many opportunities for optimizations such as Temporary Dead Code Elimination (TDCE), constant propagation, and constant folding. While constant propagation and constant folding can be incorporated into the LVN framework, they have been left as future work due to potential complexities.

Additionally, the optimization can be installed using `flit`.

> [!NOTE]
> Only the _core_ language features are considered.