### PR TITLE
Fix use of undefined variable & use set to avoid duplicate work

### DIFF
--- a/cs6120/df.py
+++ b/cs6120/df.py
@@ -106,16 +106,14 @@ class DataFlowSolver:
     def solve(self) -> Tuple[Dict[str, Any], Dict[str, Any]]:
         if self._analysis is Analysis.DEFINED:
             return self._solve(
-                func["instrs"], Flow.FORWARD, set(), defined.out, set_union
+                self._instrs, Flow.FORWARD, set(), defined.out, set_union
             )
         elif self._analysis is Analysis.CPROP:
             return self._solve(
-                func["instrs"], Flow.FORWARD, dict(), cprop.out, dict_intersection
+                self._instrs, Flow.FORWARD, dict(), cprop.out, dict_intersection
             )
         elif self._analysis is Analysis.LIVE:
-            return self._solve(
-                func["instrs"], Flow.BACKWARD, set(), live.in_, set_union
-            )
+            return self._solve(self._instrs, Flow.BACKWARD, set(), live.in_, set_union)
         else:
             raise ValueError(f"unknonw analysis {self._analysis}")
 

--- a/cs6120/df.py
+++ b/cs6120/df.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 """The data flow solver."""
 
 import argparse

--- a/cs6120/df.py
+++ b/cs6120/df.py
@@ -3,21 +3,9 @@
 import argparse
 import json
 import sys
-from collections import deque
 from copy import deepcopy
 from enum import Enum, auto
-from typing import (
-    Any,
-    Callable,
-    Deque,
-    Dict,
-    Iterable,
-    List,
-    OrderedDict,
-    Set,
-    Tuple,
-    TypeVar,
-)
+from typing import Any, Callable, Dict, Iterable, List, OrderedDict, Set, Tuple, TypeVar
 
 import cprop
 import defined
@@ -158,10 +146,10 @@ class DataFlowSolver:
             name2successors, name2predecessors = name2predecessors, name2successors
 
         # Represent the blocks with their names.
-        worklist: Deque[str] = deque(blocks.keys())
+        worklist: Set[str] = set(blocks.keys())
         while worklist:
             # We can pick any block here.
-            block_name = worklist.popleft()
+            block_name = worklist.pop()
             block = blocks[block_name]
 
             in_ = merge([outs[pred] for pred in name2predecessors[block_name]])
@@ -169,7 +157,7 @@ class DataFlowSolver:
 
             # Until the basic block converges.
             if out != outs[block_name]:
-                worklist += name2successors[block_name]
+                worklist.update(name2successors[block_name])
 
             ins[block_name] = in_
             outs[block_name] = out


### PR DESCRIPTION
In the last few commits of #7, I refactored the solver but overlooked running it again, resulting in the solver being unable to run.

Additionally, the worklist was a _deque_, which could include duplicate work. I replaced it with a _set_ to eliminate this possibility.