### PR TITLE
Fix incorrect merge function of constant propagation analysis

### DIFF
--- a/cs6120/cprop.py
+++ b/cs6120/cprop.py
@@ -2,11 +2,11 @@
 
 - At the entry and exit of each basic block, the analysis determines which variable contains a constant value.
 - This is a forward analysis.
-- For blocks with multiple predecessors, the sets are merged using `Intersection`.
+- For blocks with multiple predecessors, the sets are merged using a special `Intersection`.
 """
 
 import operator
-from typing import Any, Callable, Dict, List
+from typing import Any, Callable, Dict, Final, Iterable, List
 
 from type import Block
 
@@ -35,6 +35,27 @@ EVAL_OPS: Dict[str, Callable] = {
     "or": operator.or_,
 }
 
+UNKNOWN: Final = "?"
+
+
+def is_const(v: Any) -> bool:
+    return v != UNKNOWN
+
+
+def merge(dicts: Iterable[Dict[str, Any]]) -> Dict[str, Any]:
+    """
+    A variable can be missing from some of the predecessors as long as it is always present with the same known constant value.
+    """
+    res = {}
+    for d in dicts:
+        for k, v in d.items():
+            if k not in res:
+                res[k] = v
+            elif v != res[k]:
+                # The value diverges; mark as unknown.
+                res[k] = UNKNOWN
+    return res
+
 
 def out(b: Block, in_: Dict[str, Any]) -> Dict[str, Any]:
     """Computes the OUT set (a dict is a kind of set) for a block, performing constant propagation.
@@ -44,30 +65,28 @@ def out(b: Block, in_: Dict[str, Any]) -> Dict[str, Any]:
         in_: The IN set of constant value mappings for the block.
 
     Returns:
-        The OUT set that maps names to their constant values.
+        The OUT set that maps names to their constant values, with unknowns mapping to "?".
     """
+    # NOTE: Function arguments are not included in the IN set; they are considered as unknowns.
     res = in_.copy()  # not to modify the input
     for instr in b:
-        if "op" not in instr:
+        if "op" not in instr or "dest" not in instr:
             continue
+
         op: str = instr["op"]
+        dest: str = instr["dest"]
         if op == "const":
-            res[instr["dest"]] = instr["value"]
-        elif op == "id":
-            arg: str = instr["args"][0]
-            if arg in res:
-                # Propagate the constant.
-                res[instr["dest"]] = res[arg]
-            else:
-                # Assigned with a non-constant variable; no longer a constant.
-                res.pop(instr["dest"], None)
-        elif op in EVAL_OPS:
+            res[dest] = instr["value"]
+        elif op == "id" and instr["args"][0] in res and is_const(res[instr["args"][0]]):
+            # Propagate the constant.
+            res[dest] = res[instr["args"][0]]
+        elif op in EVAL_OPS and all(
+            arg in res and is_const(res[arg]) for arg in instr["args"]
+        ):
             # If all of the arguments are constants, calculate them.
-            args: List[str] = instr["args"]
-            if all(arg in res for arg in args):
-                vals: List[Any] = [res[arg] for arg in args]
-                res[instr["dest"]] = EVAL_OPS[op](*vals)
-            else:
-                # Assigned with a non-constant variable; no longer a constant.
-                res.pop(instr["dest"], None)
+            vals = [res[arg] for arg in instr["args"]]
+            res[dest] = EVAL_OPS[op](*vals)
+        else:
+            # Assigned with a non-constant variable; no longer a constant.
+            res[dest] = UNKNOWN
     return res

--- a/cs6120/df.py
+++ b/cs6120/df.py
@@ -49,23 +49,6 @@ def set_intersection(iterable: Iterable[Set[T]]) -> Set[T]:
         return set()
 
 
-def dict_intersection(dicts: Iterable[Dict[str, Any]]) -> Dict[str, Any]:
-    """
-    Note:
-        The key-value pairs have to be the same to be considered as intersected.
-    """
-    # Converts the dictionaries into sets of tuples to perform intersections.
-    intersections: Set[Tuple[str, Any]] = set_intersection(
-        set((k, v) for k, v in d.items()) for d in dicts
-    )
-    res: Dict[str, Any] = {}
-    for dict_ in dicts:
-        for k, v in dict_.items():
-            if (k, v) in intersections:
-                res[k] = v
-    return res
-
-
 class Analysis(Enum):
     # Reaching Definitions.
     DEFINED = auto()
@@ -99,7 +82,7 @@ class DataFlowSolver:
             )
         elif self._analysis is Analysis.CPROP:
             return self._solve(
-                self._instrs, Flow.FORWARD, dict(), cprop.out, dict_intersection
+                self._instrs, Flow.FORWARD, dict(), cprop.out, cprop.merge
             )
         elif self._analysis is Analysis.LIVE:
             return self._solve(self._instrs, Flow.BACKWARD, set(), live.in_, set_union)


### PR DESCRIPTION
While extending the LVN framework with constant propagation, I realized the implementation of this analysis was incorrect. The output sets of the predecessors should not be merged using a simple intersection. A variable can be missing from some of the predecessors as long as it is always present with the same known constant value.
To differentiate between having known values and being missing, variables with unknown values are now included in the set with a special marker value (`"?"`).