### PR TITLE
Extend lvn with constant propagation

### DIFF
--- a/cs6120/cs6120.toml
+++ b/cs6120/cs6120.toml
@@ -28,3 +28,11 @@ pipeline = [
     "./tdce.py tdce+",
     "brili -p {args}",
 ]
+
+[runs.cprop]
+pipeline = [
+    "bril2json",
+    "./lvn.py --cprop",
+    "./tdce.py tdce+",
+    "brili -p {args}",
+]

--- a/cs6120/lvn.py
+++ b/cs6120/lvn.py
@@ -156,6 +156,10 @@ def lvn(cprop: bool = False) -> None:
                         instr, block[i + 1 :], lvn_number
                     )
                     if dest != instr["dest"]:
+                        # Update the constant mapping to use the new name.
+                        if cprop:
+                            var2const[dest] = var2const.pop(instr["dest"])
+
                         instr["dest"] = dest
                         lvn_number += 1
 
@@ -166,7 +170,10 @@ def lvn(cprop: bool = False) -> None:
 
                 var2num[instr["dest"]] = the_row_num
             if cprop:
-                assert var2const == out_consts[block_name]
+                # Ensure that we performed the constant propagation correctly.
+                # NOTE: When there are reassignments, our mapping contains additional renamed variables. Variables other than these should have the same value.
+                for k, v in out_consts[block_name].items():
+                    assert var2const[k] == v
 
     json.dump(prog, indent=2, fp=sys.stdout)
 

--- a/cs6120/lvn.py
+++ b/cs6120/lvn.py
@@ -31,6 +31,64 @@ def is_commutative(op: str) -> bool:
     return op in ("add", "mul", "eq", "add", "or")
 
 
+def extract_value_repr(instr: Instr, var2num: Dict[str, int]) -> Value:
+    """
+    Returns:
+        A Value namedtuple containing the operation and its arguments.
+        For constant operations, the tuple includes the constant value and type.
+        For other operations, the arguments are replaced with their corresponding
+        row numbers if available, and sorted if the operation is commutative.
+    """
+    if instr["op"] == "const":
+        # NOTE: Since False is equal to 0 in Python, we have to include the type.
+        return Value("const", (instr["value"], instr["type"]))
+    # NOTE: If the variable isn't record, it's because such variable is defined in another basic block.
+    # In such case, there's no column number, we use the variable name directly in the tuple value.
+
+    # For function calls, we postfix the function name to the op to differentiate.
+    op = instr["op"]
+    if "funcs" in instr:
+        op += instr["funcs"][0]
+
+    # Lookup the row numbers of the operands.
+    row_nums: Tuple[Union[str, int], ...] = tuple(
+        var2num.get(arg, arg) for arg in instr["args"]
+    )
+    if is_commutative(op):
+        # Commutativity; sort the args to canonicalize.
+        # NOTE: Row numbers can be str if is defined in other basic block.
+        return Value(*sorted(row_nums, key=lambda x: str(x)))
+    return Value(op, row_nums)
+
+
+def rename_if_will_be_reassigned(
+    instr: Instr, later_instrs: List[Instr], next_lvn_number: int
+) -> str:
+    """Renames a variable if it will be reassigned in subsequent instructions.
+
+    Checks if the destination variable of the given instruction will be
+    reassigned in any of the later instructions. If so, generates a new
+    unique name for the variable and updates all references to the variable
+    in the instructions up to and including the reassignment.
+
+    Args:
+        instr: The current instruction whose destination variable may be reassigned.
+        later_instrs: A list of subsequent instructions to check for reassignment.
+        next_lvn_number: The next available unique number for renaming variables.
+
+    Returns:
+        The new name of the variable if it was reassigned, otherwise the original name.
+    """
+    for i, later_instr in enumerate(later_instrs):  # peek the later instructions
+        if instr["dest"] == later_instr.get("dest", None):
+            new_name = f"{instr['dest']}.{next_lvn_number}"
+            # all args between should be updated to use the new name.
+            # i + 1 because may be used in the reassignment.
+            rename_args_between(later_instrs[: i + 1], instr["dest"], new_name)
+            return new_name
+    return instr["dest"]
+
+
 def lvn() -> None:
     prog: Dict[str, List[Dict[str, Any]]] = json.load(sys.stdin)
 
@@ -66,27 +124,8 @@ def lvn() -> None:
                     replace_args_with_canonical(instr)
                     continue
 
-                if instr["op"] == "const":
-                    # NOTE: Since False is equal to 0 in Python, we have to include the type.
-                    val = Value("const", (instr["value"], instr["type"]))
-                else:
-                    # NOTE: If the variable isn't record, it's because such variable is defined in another basic block.
-                    # In such case, there's no column number, we use the variable name directly in the tuple value.
-
-                    # For function calls, we postfix the function name to the op to differentiate.
-                    op = instr["op"]
-                    if "funcs" in instr:
-                        op += instr["funcs"][0]
-
-                    # Lookup the row numbers of the operands.
-                    row_nums: Tuple[Union[str, int], ...] = tuple(
-                        var2num.get(arg, arg) for arg in instr["args"]
-                    )
-                    if is_commutative(op):
-                        # Commutativity; sort the args to canonicalize.
-                        # NOTE: Row numbers can be str if is defined in other basic block.
-                        val = Value(*sorted(row_nums, key=lambda x: str(x)))
-                    val = Value(op, row_nums)
+                replace_args_with_canonical(instr)
+                val: Value = extract_value_repr(instr, var2num)
 
                 if val in val2var and not has_side_effect(val.op):
                     # The value has been computed before;
@@ -98,25 +137,17 @@ def lvn() -> None:
                         instr["args"] = [var]
                 else:
                     # If the variable is going to be reassigned, we give it an unique name so that the value is correct when later instructions use it as the canonical variable.
-                    dest = instr["dest"]
-                    for j in range(i + 1, len(block)):  # peek the later instructions
-                        later_instr = block[j]
-                        if dest == later_instr.get("dest", None):
-                            new_name = f"{dest}.{lvn_number}"
-                            lvn_number += 1
-                            # all args between should be updated to use the new name.
-                            # j + 1 because may be used in the reassignment.
-                            rename_args_between(block[i + 1 : j + 1], dest, new_name)
-                            dest = new_name
-                            instr["dest"] = dest
-                            break
+                    dest = rename_if_will_be_reassigned(
+                        instr, block[i + 1 :], lvn_number
+                    )
+                    if dest != instr["dest"]:
+                        instr["dest"] = dest
+                        lvn_number += 1
 
                     # A new value.
                     the_row_num = row_num
                     row_num += 1
                     val2var[val] = dest, the_row_num
-
-                    replace_args_with_canonical(instr)
 
                 var2num[instr["dest"]] = the_row_num
 

--- a/cs6120/lvn.py
+++ b/cs6120/lvn.py
@@ -30,7 +30,7 @@ def has_side_effect(op: str) -> bool:
 
 def is_commutative(op: str) -> bool:
     # No short circuit for "add" and "or" at this level.
-    return op in ("add", "mul", "eq", "add", "or")
+    return op in ("add", "mul", "eq", "and", "or")
 
 
 def extract_value_repr(instr: Instr, var2num: Dict[str, int]) -> Value:
@@ -59,7 +59,7 @@ def extract_value_repr(instr: Instr, var2num: Dict[str, int]) -> Value:
     if is_commutative(op):
         # Commutativity; sort the args to canonicalize.
         # NOTE: Row numbers can be str if is defined in other basic block.
-        return Value(*sorted(row_nums, key=lambda x: str(x)))
+        row_nums = tuple(sorted(row_nums, key=lambda x: str(x)))
     return Value(op, row_nums)
 
 

--- a/cs6120/test/lvn/clobber-arg.bril
+++ b/cs6120/test/lvn/clobber-arg.bril
@@ -1,0 +1,6 @@
+@main() {
+  a: int = const 1;
+  b: int = const 2;
+.lbl:
+  b: int = add a b;
+}

--- a/cs6120/test/lvn/clobber-arg.out
+++ b/cs6120/test/lvn/clobber-arg.out
@@ -1,0 +1,6 @@
+@main {
+  a: int = const 1;
+  b: int = const 2;
+.lbl:
+  b: int = add a b;
+}

--- a/cs6120/test/lvn/clobber-fold.bril
+++ b/cs6120/test/lvn/clobber-fold.bril
@@ -1,0 +1,21 @@
+# CMD: bril2json < {filename} | python3 ../../lvn.py -c | python3 ../../tdce.py tdce | bril2txt
+#
+@main {
+  a: int = const 4;
+  b: int = const 2;
+
+  # (a + b) * (a + b)
+  sum1: int = add a b;
+  sum2: int = add a b;
+  prod1: int = mul sum1 sum2;
+
+  # Clobber both sums.
+  sum1: int = const 0;
+  sum2: int = const 0;
+
+  # Use the sums again.
+  sum3: int = add a b;
+  prod2: int = mul sum3 sum3;
+
+  print prod2;
+}

--- a/cs6120/test/lvn/clobber-fold.out
+++ b/cs6120/test/lvn/clobber-fold.out
@@ -1,0 +1,4 @@
+@main {
+  prod1: int = const 36;
+  print prod1;
+}

--- a/cs6120/test/lvn/clobber.bril
+++ b/cs6120/test/lvn/clobber.bril
@@ -1,0 +1,21 @@
+# CMD: bril2json < {filename} | python3 ../../lvn.py | python3 ../../tdce.py tdce | bril2txt
+#
+@main {
+  a: int = const 4;
+  b: int = const 2;
+
+  # (a + b) * (a + b)
+  sum1: int = add a b;
+  sum2: int = add a b;
+  prod1: int = mul sum1 sum2;
+
+  # Clobber both sums.
+  sum1: int = const 0;
+  sum2: int = const 0;
+
+  # Use the sums again.
+  sum3: int = add a b;
+  prod2: int = mul sum3 sum3;
+
+  print prod2;
+}

--- a/cs6120/test/lvn/clobber.out
+++ b/cs6120/test/lvn/clobber.out
@@ -1,0 +1,7 @@
+@main {
+  a: int = const 4;
+  b: int = const 2;
+  sum1.0: int = add a b;
+  prod1: int = mul sum1.0 sum1.0;
+  print prod1;
+}

--- a/cs6120/test/lvn/commute.bril
+++ b/cs6120/test/lvn/commute.bril
@@ -1,0 +1,9 @@
+# (a + b) * (b + a)
+@main {
+  a: int = const 4;
+  b: int = const 2;
+  sum1: int = add a b;
+  sum2: int = add b a;
+  prod: int = mul sum1 sum2;
+  print prod;
+}

--- a/cs6120/test/lvn/commute.out
+++ b/cs6120/test/lvn/commute.out
@@ -1,0 +1,8 @@
+@main {
+  a: int = const 4;
+  b: int = const 2;
+  sum1: int = add a b;
+  sum2: int = id sum1;
+  prod: int = mul sum1 sum1;
+  print prod;
+}

--- a/cs6120/test/lvn/divide-by-zero.bril
+++ b/cs6120/test/lvn/divide-by-zero.bril
@@ -1,0 +1,7 @@
+@main {
+.entry:
+  zero : int = const 0;
+  one : int = const 1;
+  baddiv : int = div one zero;
+  print baddiv;
+}

--- a/cs6120/test/lvn/divide-by-zero.out
+++ b/cs6120/test/lvn/divide-by-zero.out
@@ -1,0 +1,7 @@
+@main {
+.entry:
+  zero: int = const 0;
+  one: int = const 1;
+  baddiv: int = div one zero;
+  print baddiv;
+}

--- a/cs6120/test/lvn/fold-comparisons.bril
+++ b/cs6120/test/lvn/fold-comparisons.bril
@@ -1,0 +1,21 @@
+# ARGS: -c
+@main(arg1: int, arg2: int) {
+  a: int = const 4;
+  b: int = const 3;
+  constant_fold2: bool = eq a b;
+  constant_fold3: bool = le a b;
+  constant_fold4: bool = lt b a;
+  constant_fold5: bool = gt b a;
+  constant_fold6: bool = ge b a;
+
+  should_fold1: bool = eq arg1 arg1;
+  should_fold2: bool = le arg1 arg1;
+  should_fold3: bool = ge arg1 arg1;
+  should_fold4: bool = lt arg1 arg1;
+  should_fold5: bool = gt arg2 arg2;
+
+  no_fold1: bool = eq arg1 arg2;
+  no_fold2: bool = le arg1 arg2;
+  no_fold3: bool = ge arg1 arg2;
+
+}

--- a/cs6120/test/lvn/fold-comparisons.out
+++ b/cs6120/test/lvn/fold-comparisons.out
@@ -1,0 +1,17 @@
+@main(arg1: int, arg2: int) {
+  a: int = const 4;
+  b: int = const 3;
+  constant_fold2: bool = const false;
+  constant_fold3: bool = const false;
+  constant_fold4: bool = const true;
+  constant_fold5: bool = const false;
+  constant_fold6: bool = const false;
+  should_fold1: bool = const true;
+  should_fold2: bool = const true;
+  should_fold3: bool = const true;
+  should_fold4: bool = const false;
+  should_fold5: bool = const false;
+  no_fold1: bool = eq arg1 arg2;
+  no_fold2: bool = le arg1 arg2;
+  no_fold3: bool = ge arg1 arg2;
+}

--- a/cs6120/test/lvn/idchain-nonlocal.bril
+++ b/cs6120/test/lvn/idchain-nonlocal.bril
@@ -1,0 +1,9 @@
+@main {
+  x: int = const 4;
+  jmp .label;
+.label:
+  copy1: int = id x;
+  copy2: int = id copy1;
+  copy3: int = id copy2;
+  print copy3;
+}

--- a/cs6120/test/lvn/idchain-nonlocal.out
+++ b/cs6120/test/lvn/idchain-nonlocal.out
@@ -1,0 +1,9 @@
+@main {
+  x: int = const 4;
+  jmp .label;
+.label:
+  copy1: int = id x;
+  copy2: int = id x;
+  copy3: int = id x;
+  print x;
+}

--- a/cs6120/test/lvn/idchain-prop.bril
+++ b/cs6120/test/lvn/idchain-prop.bril
@@ -1,0 +1,8 @@
+# ARGS: -c
+@main {
+  x: int = const 4;
+  copy1: int = id x;
+  copy2: int = id copy1;
+  copy3: int = id copy2;
+  print copy3;
+}

--- a/cs6120/test/lvn/idchain-prop.out
+++ b/cs6120/test/lvn/idchain-prop.out
@@ -1,0 +1,7 @@
+@main {
+  x: int = const 4;
+  copy1: int = const 4;
+  copy2: int = const 4;
+  copy3: int = const 4;
+  print x;
+}

--- a/cs6120/test/lvn/idchain.bril
+++ b/cs6120/test/lvn/idchain.bril
@@ -1,0 +1,7 @@
+@main {
+  x: int = const 4;
+  copy1: int = id x;
+  copy2: int = id copy1;
+  copy3: int = id copy2;
+  print copy3;
+}

--- a/cs6120/test/lvn/idchain.out
+++ b/cs6120/test/lvn/idchain.out
@@ -1,0 +1,7 @@
+@main {
+  x: int = const 4;
+  copy1: int = id x;
+  copy2: int = id x;
+  copy3: int = id x;
+  print x;
+}

--- a/cs6120/test/lvn/logical-operators.bril
+++ b/cs6120/test/lvn/logical-operators.bril
@@ -1,0 +1,26 @@
+# ARGS: -c
+
+@main(arg1: bool, arg2: bool) {
+  t: bool = const true;
+  f: bool = const false;
+
+  constant_fold1: bool = and f t;
+  constant_fold2: bool = and t f;
+  constant_fold3: bool = or t f;
+  constant_fold4: bool = or f t;
+  constant_fold5: bool = not t;
+  constant_fold6: bool = not f;
+
+  should_fold1: bool = and f arg1;
+  should_fold2: bool = and arg1 f;
+  should_fold3: bool = or t arg1;
+  should_fold4: bool = or arg1 t;
+
+  no_fold1: bool = and t arg1;
+  no_fold2: bool = and arg1 t;
+  no_fold3: bool = or f arg1;
+  no_fold4: bool = or arg1 f;
+  no_fold5: bool = and arg1 arg2;
+  no_fold6: bool = or arg1 arg2;
+  no_fold7: bool = not arg1;
+}

--- a/cs6120/test/lvn/logical-operators.out
+++ b/cs6120/test/lvn/logical-operators.out
@@ -1,0 +1,21 @@
+@main(arg1: bool, arg2: bool) {
+  t: bool = const true;
+  f: bool = const false;
+  constant_fold1: bool = const false;
+  constant_fold2: bool = const false;
+  constant_fold3: bool = const true;
+  constant_fold4: bool = const true;
+  constant_fold5: bool = const false;
+  constant_fold6: bool = const true;
+  should_fold1: bool = const false;
+  should_fold2: bool = const false;
+  should_fold3: bool = const true;
+  should_fold4: bool = const true;
+  no_fold1: bool = and t arg1;
+  no_fold2: bool = id no_fold1;
+  no_fold3: bool = or f arg1;
+  no_fold4: bool = id no_fold3;
+  no_fold5: bool = and arg1 arg2;
+  no_fold6: bool = or arg1 arg2;
+  no_fold7: bool = not arg1;
+}

--- a/cs6120/test/lvn/nonlocal-clobber.bril
+++ b/cs6120/test/lvn/nonlocal-clobber.bril
@@ -1,0 +1,7 @@
+@main {
+  x: int = const 1;
+.lb:
+  y: int = id x;
+  x: int = add x x;
+  print y;
+}

--- a/cs6120/test/lvn/nonlocal-clobber.out
+++ b/cs6120/test/lvn/nonlocal-clobber.out
@@ -1,0 +1,7 @@
+@main {
+  x: int = const 1;
+.lb:
+  y: int = id x;
+  x: int = add x x;
+  print y;
+}

--- a/cs6120/test/lvn/nonlocal.bril
+++ b/cs6120/test/lvn/nonlocal.bril
@@ -1,0 +1,10 @@
+@main {
+  a: int = const 4;
+  b: int = const 2;
+  sum1: int = add a b;
+  sum2: int = add a b;
+  jmp .label;
+.label:
+  prod: int = mul sum1 sum2;
+  print prod;
+}

--- a/cs6120/test/lvn/nonlocal.out
+++ b/cs6120/test/lvn/nonlocal.out
@@ -1,0 +1,10 @@
+@main {
+  a: int = const 4;
+  b: int = const 2;
+  sum1: int = add a b;
+  sum2: int = id sum1;
+  jmp .label;
+.label:
+  prod: int = mul sum1 sum2;
+  print prod;
+}

--- a/cs6120/test/lvn/reassign.bril
+++ b/cs6120/test/lvn/reassign.bril
@@ -1,0 +1,5 @@
+@main {
+  a: int = const 100;
+  a: int = const 42;
+  print a;
+}

--- a/cs6120/test/lvn/reassign.out
+++ b/cs6120/test/lvn/reassign.out
@@ -1,0 +1,5 @@
+@main {
+  a.0: int = const 100;
+  a: int = const 42;
+  print a;
+}

--- a/cs6120/test/lvn/redundant-dce.bril
+++ b/cs6120/test/lvn/redundant-dce.bril
@@ -1,0 +1,10 @@
+# CMD: bril2json < {filename} | python3 ../../lvn.py | python3 ../../tdce.py tdce | bril2txt
+
+@main {
+  a: int = const 4;
+  b: int = const 2;
+  sum1: int = add a b;
+  sum2: int = add a b;
+  prod: int = mul sum1 sum2;
+  print prod;
+}

--- a/cs6120/test/lvn/redundant-dce.out
+++ b/cs6120/test/lvn/redundant-dce.out
@@ -1,0 +1,7 @@
+@main {
+  a: int = const 4;
+  b: int = const 2;
+  sum1: int = add a b;
+  prod: int = mul sum1 sum1;
+  print prod;
+}

--- a/cs6120/test/lvn/redundant.bril
+++ b/cs6120/test/lvn/redundant.bril
@@ -1,0 +1,9 @@
+# (a + b) * (a + b)
+@main {
+  a: int = const 4;
+  b: int = const 2;
+  sum1: int = add a b;
+  sum2: int = add a b;
+  prod: int = mul sum1 sum2;
+  print prod;
+}

--- a/cs6120/test/lvn/redundant.out
+++ b/cs6120/test/lvn/redundant.out
@@ -1,0 +1,8 @@
+@main {
+  a: int = const 4;
+  b: int = const 2;
+  sum1: int = add a b;
+  sum2: int = id sum1;
+  prod: int = mul sum1 sum1;
+  print prod;
+}

--- a/cs6120/test/lvn/rename-fold.bril
+++ b/cs6120/test/lvn/rename-fold.bril
@@ -1,0 +1,10 @@
+# CMD: bril2json < {filename} | python3 ../../lvn.py -c | python3 ../../tdce.py tdce | bril2txt
+@main {
+  v1: int = const 4;
+  v2: int = const 0;
+  mul1: int = mul v1 v2;
+  add1: int = add v1 v2;
+  v2: int = const 3;
+  print mul1;
+  print add1;
+}

--- a/cs6120/test/lvn/rename-fold.out
+++ b/cs6120/test/lvn/rename-fold.out
@@ -1,0 +1,6 @@
+@main {
+  v1: int = const 4;
+  v2.0: int = const 0;
+  print v2.0;
+  print v1;
+}

--- a/cs6120/test/lvn/turnt.toml
+++ b/cs6120/test/lvn/turnt.toml
@@ -1,0 +1,1 @@
+command = "bril2json < {filename} | python3 ../../lvn.py {args} | bril2txt"


### PR DESCRIPTION
This pull request enhances the LVN framework by incorporating constant propagation and constant folding. Along with TDCE, these improvements, particularly copy propagation, enable the elimination of a significantly larger number of instructions.

During the implementation, several issues were identified and resolved:
1. The capability for constant folding was too limited.
2. Some benchmarks had missing terminators in certain basic blocks, causing compilation errors.
3. Copy propagation is crucial for unlocking additional TDCE opportunities.

This PR addresses and resolves all of the above issues.