### PR TITLE
Add dominance analyses

### DIFF
--- a/cs6120/dom.py
+++ b/cs6120/dom.py
@@ -47,6 +47,20 @@ def dom_tree(cfg: ControlFlowGraph) -> Dict[str, List[str]]:
     return tree
 
 
+def dom_front(cfg: ControlFlowGraph) -> Dict[str, List[str]]:
+    # If A dominates B but not C, where C is a successor of B, then C is in the dominance frontiers of A.
+    dom = get_dom(cfg)
+    front: Dict[str, List[str]] = {b: [] for b in cfg.blocks}
+    for c in cfg.blocks:
+        for b in cfg.predecessors_of(c):
+            for a in dom[b]:
+                # If a == c, there's a loop, and c is the header.
+                # It's a frontier of itself.
+                if a not in dom[c] or a == c:
+                    front[a].append(c)
+    return {b: sorted(l) for b, l in front.items()}
+
+
 def set2sortedlist(o) -> List:
     if isinstance(o, set):
         return sorted(list(o))
@@ -56,6 +70,7 @@ def set2sortedlist(o) -> List:
 COMMANDS = {
     "dom": get_dom,
     "tree": dom_tree,
+    "front": dom_front,
 }
 
 

--- a/cs6120/dom.py
+++ b/cs6120/dom.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+
+import argparse
+import functools
+import json
+import operator
+import sys
+from typing import Any, Dict, List, Set
+
+from cfg import ControlFlowGraph
+
+
+def get_dom(cfg: ControlFlowGraph) -> Dict[str, Set[str]]:
+    # The operator is set intersection; initialized with the set of all blocks.
+    dom: Dict[str, Set[str]] = {b: set(cfg.blocks) for b in cfg.blocks}
+    dom[cfg.entry] = {cfg.entry}
+    changed = True
+    while changed:
+        changed = False
+        for vertex in cfg.blocks:
+            new_dom = set([vertex])
+            try:
+                new_dom |= functools.reduce(
+                    operator.and_, (dom[x] for x in cfg.predecessors_of(vertex))
+                )
+            except TypeError:
+                # The vertex has no predecessor.
+                # It's the entry block, or it's unreachable.
+                pass
+            if new_dom != dom[vertex]:
+                dom[vertex] = new_dom
+                changed = True
+    return dom
+
+
+def set2sortedlist(o) -> List:
+    if isinstance(o, set):
+        return sorted(list(o))
+    raise TypeError(f"Object of type {o.__class__.__name__} is not JSON serializable")
+
+
+COMMANDS = {
+    "dom": get_dom,
+}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(sys.argv[0])
+    parser.add_argument(
+        "cmd",
+        choices=COMMANDS.keys(),
+        metavar="CMD",
+        help=f"[{'|'.join(COMMANDS.keys())}]",
+    )
+    args = parser.parse_args()
+
+    prog: Dict[str, List[Dict[str, Any]]] = json.load(sys.stdin)
+
+    for func in prog["functions"]:
+        cfg = ControlFlowGraph(func["instrs"])
+        cfg.ensure_entry()
+        print(
+            json.dumps(
+                COMMANDS[args.cmd](cfg),
+                default=set2sortedlist,
+                indent=2,
+                sort_keys=True,
+            )
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/cs6120/dom.py
+++ b/cs6120/dom.py
@@ -33,6 +33,20 @@ def get_dom(cfg: ControlFlowGraph) -> Dict[str, Set[str]]:
     return dom
 
 
+def dom_tree(cfg: ControlFlowGraph) -> Dict[str, List[str]]:
+    dom = get_dom(cfg)
+    tree = {}
+    queue = [cfg.entry]
+    while queue:
+        par = queue.pop(0)
+        succs = cfg.successors_of(par)
+        chd = [succ for succ in succs if par in dom[succ]]
+        queue.extend(chd)
+        # sorted just for convenience of testing
+        tree[par] = sorted(chd)
+    return tree
+
+
 def set2sortedlist(o) -> List:
     if isinstance(o, set):
         return sorted(list(o))
@@ -41,6 +55,7 @@ def set2sortedlist(o) -> List:
 
 COMMANDS = {
     "dom": get_dom,
+    "tree": dom_tree,
 }
 
 

--- a/cs6120/test/dom/lcm.bril
+++ b/cs6120/test/dom/lcm.bril
@@ -1,0 +1,33 @@
+@main(x: int, y: int) {
+  greater: int = id y;
+  v4: bool = gt x y;
+  br v4 .then.1 .else.1;
+.then.1:
+  greater: int = id x;
+  jmp .endif.1;
+.else.1:
+.endif.1:
+.foreverloop:
+  modX : int = call @getMod greater x;
+  modY : int = call @getMod greater y;
+  zero: int = const 0;
+  xZero : bool = eq modX zero;
+  yZero : bool = eq modY zero;
+  bothZero : bool = and xZero yZero;
+  br bothZero .then.2 .else.2;
+.then.2:
+  print greater;
+  jmp .loopend;
+.else.2:
+  one: int = const 1;
+  greater:int = add greater one;
+  jmp .foreverloop;
+.loopend:
+}
+
+@getMod(val: int, mod: int): int{
+  divisor: int = div val mod;
+  multiple: int = mul divisor mod;
+  rem: int = sub val multiple;
+  ret rem;
+}

--- a/cs6120/test/dom/lcm.dom.json
+++ b/cs6120/test/dom/lcm.dom.json
@@ -1,0 +1,46 @@
+{
+  "b0": [
+    "b0"
+  ],
+  "else.1": [
+    "b0",
+    "else.1"
+  ],
+  "else.2": [
+    "b0",
+    "else.2",
+    "endif.1",
+    "foreverloop"
+  ],
+  "endif.1": [
+    "b0",
+    "endif.1"
+  ],
+  "foreverloop": [
+    "b0",
+    "endif.1",
+    "foreverloop"
+  ],
+  "loopend": [
+    "b0",
+    "endif.1",
+    "foreverloop",
+    "loopend",
+    "then.2"
+  ],
+  "then.1": [
+    "b0",
+    "then.1"
+  ],
+  "then.2": [
+    "b0",
+    "endif.1",
+    "foreverloop",
+    "then.2"
+  ]
+}
+{
+  "b0": [
+    "b0"
+  ]
+}

--- a/cs6120/test/dom/lcm.front.json
+++ b/cs6120/test/dom/lcm.front.json
@@ -1,0 +1,21 @@
+{
+  "b0": [],
+  "else.1": [
+    "endif.1"
+  ],
+  "else.2": [
+    "foreverloop"
+  ],
+  "endif.1": [],
+  "foreverloop": [
+    "foreverloop"
+  ],
+  "loopend": [],
+  "then.1": [
+    "endif.1"
+  ],
+  "then.2": []
+}
+{
+  "b0": []
+}

--- a/cs6120/test/dom/lcm.tree.json
+++ b/cs6120/test/dom/lcm.tree.json
@@ -1,0 +1,24 @@
+{
+  "b0": [
+    "else.1",
+    "endif.1",
+    "then.1"
+  ],
+  "else.1": [],
+  "else.2": [],
+  "endif.1": [
+    "foreverloop"
+  ],
+  "foreverloop": [
+    "else.2",
+    "then.2"
+  ],
+  "loopend": [],
+  "then.1": [],
+  "then.2": [
+    "loopend"
+  ]
+}
+{
+  "b0": []
+}

--- a/cs6120/test/dom/loopcond.bril
+++ b/cs6120/test/dom/loopcond.bril
@@ -1,0 +1,30 @@
+@main {
+.entry:
+  x: int = const 0;
+  i: int = const 0;
+  one: int = const 1;
+
+.loop:
+  max: int = const 10;
+  cond: bool = lt i max;
+  br cond .body .exit;
+
+.body:
+  mid: int = const 5;
+  cond: bool = lt i mid;
+  br cond .then .endif;
+
+.then:
+  x: int = add x one;
+  jmp .endif;
+
+.endif:
+  factor: int = const 2;
+  x: int = mul x factor;
+
+  i: int = add i one;
+  jmp .loop;
+
+.exit:
+  print x;
+}

--- a/cs6120/test/dom/loopcond.dom.json
+++ b/cs6120/test/dom/loopcond.dom.json
@@ -1,0 +1,31 @@
+{
+  "body": [
+    "body",
+    "entry",
+    "loop"
+  ],
+  "endif": [
+    "body",
+    "endif",
+    "entry",
+    "loop"
+  ],
+  "entry": [
+    "entry"
+  ],
+  "exit": [
+    "entry",
+    "exit",
+    "loop"
+  ],
+  "loop": [
+    "entry",
+    "loop"
+  ],
+  "then": [
+    "body",
+    "entry",
+    "loop",
+    "then"
+  ]
+}

--- a/cs6120/test/dom/loopcond.front.json
+++ b/cs6120/test/dom/loopcond.front.json
@@ -1,0 +1,16 @@
+{
+  "body": [
+    "loop"
+  ],
+  "endif": [
+    "loop"
+  ],
+  "entry": [],
+  "exit": [],
+  "loop": [
+    "loop"
+  ],
+  "then": [
+    "endif"
+  ]
+}

--- a/cs6120/test/dom/loopcond.tree.json
+++ b/cs6120/test/dom/loopcond.tree.json
@@ -1,0 +1,16 @@
+{
+  "body": [
+    "endif",
+    "then"
+  ],
+  "endif": [],
+  "entry": [
+    "loop"
+  ],
+  "exit": [],
+  "loop": [
+    "body",
+    "exit"
+  ],
+  "then": []
+}

--- a/cs6120/test/dom/turnt.toml
+++ b/cs6120/test/dom/turnt.toml
@@ -1,0 +1,11 @@
+[envs.dom]
+command = "bril2json < {filename} | ../../dom.py dom"
+output."dom.json" = "-"
+
+[envs.front]
+command = "bril2json < {filename} | ../../dom.py front"
+output."front.json" = "-"
+
+[envs.tree]
+command = "bril2json < {filename} | ../../dom.py tree"
+output."tree.json" = "-"

--- a/cs6120/test/dom/while.bril
+++ b/cs6120/test/dom/while.bril
@@ -1,0 +1,12 @@
+@main(a: int) {
+.while.cond:
+  zero: int = const 0;
+  is_term: bool = eq a zero;
+  br is_term .while.finish .while.body;
+.while.body:
+  one: int = const 1;
+  a: int = sub a one;
+  jmp .while.cond;
+.while.finish:
+  print a;
+}

--- a/cs6120/test/dom/while.dom.json
+++ b/cs6120/test/dom/while.dom.json
@@ -1,0 +1,19 @@
+{
+  "entry.1": [
+    "entry.1"
+  ],
+  "while.body": [
+    "entry.1",
+    "while.body",
+    "while.cond"
+  ],
+  "while.cond": [
+    "entry.1",
+    "while.cond"
+  ],
+  "while.finish": [
+    "entry.1",
+    "while.cond",
+    "while.finish"
+  ]
+}

--- a/cs6120/test/dom/while.front.json
+++ b/cs6120/test/dom/while.front.json
@@ -1,0 +1,10 @@
+{
+  "entry1": [],
+  "while.body": [
+    "while.cond"
+  ],
+  "while.cond": [
+    "while.cond"
+  ],
+  "while.finish": []
+}

--- a/cs6120/test/dom/while.front.json
+++ b/cs6120/test/dom/while.front.json
@@ -1,5 +1,5 @@
 {
-  "entry1": [],
+  "entry.1": [],
   "while.body": [
     "while.cond"
   ],

--- a/cs6120/test/dom/while.tree.json
+++ b/cs6120/test/dom/while.tree.json
@@ -1,0 +1,11 @@
+{
+  "entry1": [
+    "while.cond"
+  ],
+  "while.body": [],
+  "while.cond": [
+    "while.body",
+    "while.finish"
+  ],
+  "while.finish": []
+}

--- a/cs6120/test/dom/while.tree.json
+++ b/cs6120/test/dom/while.tree.json
@@ -1,5 +1,5 @@
 {
-  "entry1": [
+  "entry.1": [
     "while.cond"
   ],
   "while.body": [],


### PR DESCRIPTION
This pull request completes the tasks for Lesson 5 by implementing the following dominance utilities: finding dominators of a function, constructing the dominance tree, and computing the dominance frontier.

To find the dominators, I implemented the naive _O(n^2)_ algorithm described in class. The dominance tree is then constructed using the dominators, along with the insight that "For block x to be the intermediate dominator of y, all other dominators of y should also dominate x."[^1] I had difficulty figuring out how to construct the dominance tree correctly. Initially, I came up with the intuition that "x is the intermediate dominator of y when x dominates y and x is the predecessor of y." However, this intuition didn't cover more complicated cases where conditions are involved, and the control flow graph has a diamond shape. I searched online and only found sophisticated algorithms, and [the reference solution in the example](https://github.com/sampsyo/bril/blob/4029dd7b6440074bc4dd5557022848ef378f978a/examples/dom.py#L93-L104) was difficult to understand. When computing the dominance frontier, I initially missed the case where the header of a loop is the dominance frontier of itself.

To test these implementations, I performed differential testing against the reference solution on a few benchmark tests and conducted snapshot tests on four programs.

[^1]: https://github.com/sampsyo/cs6120/discussions/350#discussioncomment-7071788